### PR TITLE
Update Emogotchi live URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # emogotchi
 A simple parody of Tamagotchi, in which you actively have to help your Emo stay miserable to avoid losing the game. Written to demonstrate the [W3C Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API).
 
-You can [view the Emogotchi live](http://mdn.github.io/emogotchi/).
+You can [view the Emogotchi live](https://chrisdavidmills.github.io/emogotchi/).


### PR DESCRIPTION
Should change the Emogotchi live URL because there was no repository under https://github.com/mdn/emogotchi